### PR TITLE
Filter branches for "HEAD ->"

### DIFF
--- a/audit_repo_cloner/create_audit_repo.py
+++ b/audit_repo_cloner/create_audit_repo.py
@@ -464,6 +464,7 @@ def create_audit_tag(repo, repo_path, commit_hash) -> Repository:
             branches = [
                 b.strip().split("/", 1)[1]
                 for b in completed_process.stdout.strip().split("\n")
+                if not b.strip().startswith("HEAD ->")
             ]
 
             if not branches:


### PR DESCRIPTION
This PR performs some additional filtering on the branches of a given commit to remove anything that starts with `HEAD ->`. Closes #8.