### PR TITLE
Project board setup scripts added

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,8 @@
-GITHUB_ACCESS_TOKEN=<github-token>
-GITHUB_ORGANIZATION=Cyfrin
-SOURCE_REPO_URL=<url-of-the-source-repo>
-COMMIT_HASH=<full-commit-hash-of-the-scope>
-TARGET_REPO_NAME=<target-repo-name>
-PROJECT_TEMPLATE_ID=5
-PROJECT_TITLE=<project-board-title>
+GITHUB_ACCESS_TOKEN="<github-token>"
+GITHUB_ORGANIZATION="<github-organization>"
+
+SOURCE_REPO_URL="<url-of-the-source-repo>"
+COMMIT_HASH="<full-commit-hash>"
+TARGET_REPO_NAME="<target-repo-name>"
+ASSIGNED_AUDITORS="<auditor1 auditor2>"
+PROJECT_TITLE="<project-board-title>"

--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,7 @@
-ACCESS_TOKEN=<your-github-token>
-GITHUB_ORGANIZATION=<your-github-organization>
+GITHUB_ACCESS_TOKEN=<github-token>
+GITHUB_ORGANIZATION=Cyfrin
+SOURCE_REPO_URL=<url-of-the-source-repo>
+COMMIT_HASH=<full-commit-hash-of-the-scope>
+TARGET_REPO_NAME=<target-repo-name>
+PROJECT_TEMPLATE_ID=5
+PROJECT_TITLE=<project-board-title>

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ To use this, you'll need a [github personal access token](https://docs.github.co
 You can then set it as an environment variable or input it via the CLI:
 
 ```bash
-export ACCESS_TOKEN=xxxxxx
+export GITHUB_ACCESS_TOKEN=xxxxxx
 ```
 
 Note: this access token is only used to create the repo initially. To allow the GitHub Action to run the report generator (fetching issues) in CI, be sure to set appropriate permissions for the global [`GITHUB_TOKEN` secret](https://docs.github.com/en/actions/security-guides/automatic-token-authentication).
@@ -126,7 +126,7 @@ Enter: `https://github.com/Cyfrin/foundry-full-course-f23`
 Enter: `""`
 
 ```
-3) Audit commit hash: 
+3) Audit commit hash (be sure to copy the full SHA): 
 ```
 Enter: `25d62b685857f5c1906675a3876d7d7773a8b3bd`
 
@@ -141,4 +141,17 @@ Enter: `"tricky-p blue-frog-man giiioooooooo"`
 
 Enter: `<YOUR_ORG_NAME>`
 
+```
+6) Enter the title of the GitHub project board: 
+```
+
+Enter: `Cyfrin Audit`
+
 And you'll get a loooong output, but, hopefully, you'll have a repo ready for audit!
+
+### Project Board Configuration
+To create and link a GitHub project board, you'll first need to manually create a template project board in your organization. This only needs to be done once and can be used for all subsequent runs of this tool. The resource identifier for the template project board will be the number at the end of the URL. For example, if the URL is `https://github.com/orgs/Cyfrin/projects/5/views/1` then the resource identifier is `5`. This identifier will be used to get the global node ID for the project board, which is used to link the project board to the audit repository. The ID of Cyfrin's template project board is `5` and is set as a constant in `constants.py`:
+```python
+PROJECT_TEMPLATE_ID = 5
+```
+If forking this repo or updating the template project board, change this value to the ID of your desired template project board accordingly.

--- a/audit_repo_cloner/constants.py
+++ b/audit_repo_cloner/constants.py
@@ -43,6 +43,9 @@ SEVERITY_DATA = [
     {"name": "Report Status: Resolved", "color": "0E8A16"},
     {"name": "Report Status: Closed", "color": "bfdadc"},
 ]
+
+PROJECT_TEMPLATE_ID = "5"
+
 TRELLO_LABELS = [
     "Archived",
     "Needs Discussion",
@@ -50,4 +53,5 @@ TRELLO_LABELS = [
     "Co-Validated",
     "Report Ready",
 ]
+
 TRELLO_COLUMNS = ["Archive", "Ideas", "Findings", "Peer Reviewed", "Report"]

--- a/audit_repo_cloner/create_audit_repo.py
+++ b/audit_repo_cloner/create_audit_repo.py
@@ -49,7 +49,6 @@ GITHUB_WORKFLOW_ACTION_NAME = "generate-report"
 @click.option("--project-template-id", help="ID of the GitHub project board template.", default=os.getenv("PROJECT_TEMPLATE_ID"))
 @click.option("--project-title", help="Title of the new project board on GitHub.", default=os.getenv("PROJECT_TITLE"))
 def create_audit_repo(
-    config: str = "",
     source_url: str = None,
     target_repo_name: str = None,
     commit_hash: str = None,

--- a/audit_repo_cloner/create_audit_repo.py
+++ b/audit_repo_cloner/create_audit_repo.py
@@ -141,7 +141,6 @@ def create_audit_repo(
             commit_hash,
         )
         repo = set_up_ci(repo, subtree_path)
-        # repo = set_up_project_board(repo, source_username, target_repo_name)
         # create project board optionally
         if project_template_id and project_title:
             set_up_project_board(token=github_token, org_name=organization, project_template_id=project_template_id, project_title=project_title)

--- a/audit_repo_cloner/create_audit_repo.py
+++ b/audit_repo_cloner/create_audit_repo.py
@@ -39,7 +39,6 @@ GITHUB_WORKFLOW_ACTION_NAME = "generate-report"
     version=__version__,
     prog_name=__title__,
 )
-@click.option("--config", type=click.Path(exists=True), help="Path to YAML config file")
 @click.option("--source-url", help="Source repository URL.", default=os.getenv("SOURCE_REPO_URL"))
 @click.option("--target-repo-name", help="Target repository name (leave blank to use source repo name).", default=os.getenv("TARGET_REPO_NAME"))
 @click.option("--commit-hash", help="Audit commit hash.", default=os.getenv("COMMIT_HASH"))

--- a/audit_repo_cloner/create_audit_repo.py
+++ b/audit_repo_cloner/create_audit_repo.py
@@ -9,7 +9,6 @@ import click
 import subprocess
 import tempfile
 import logging as log
-import yaml
 import re
 from __version__ import __version__, __title__
 
@@ -17,8 +16,6 @@ from constants import (
     ISSUE_TEMPLATE,
     DEFAULT_LABELS,
     SEVERITY_DATA,
-    TRELLO_LABELS,
-    TRELLO_COLUMNS,
 )
 
 log.basicConfig(level=log.INFO)
@@ -140,7 +137,9 @@ def create_audit_repo(
         repo = set_up_ci(repo, subtree_path)
         # create project board optionally
         if project_template_id and project_title:
-            set_up_project_board(token=github_token, org_name=organization, project_template_id=project_template_id, project_title=project_title)
+            set_up_project_board(repo, github_token, organization, target_repo_name, project_template_id, project_title)
+        else: 
+            print("Please set up project board manually.")
 
 
     print("Done!")
@@ -599,9 +598,16 @@ def create_report_branch(repo, commit_hash) -> Repository:
 # IMPORTANT: project creation via REST API is not supported anymore
 # https://stackoverflow.com/questions/73268885/unable-to-create-project-in-repository-or-organisation-using-github-rest-api
 # we use a non-standard way to access GitHub's GraphQL
-def set_up_project_board(token:str, org_name:str, project_template_id:str, project_title:str):
+def set_up_project_board(
+        repo: Repository,
+        github_token: str,
+        organization: str,
+        target_repo_name: str,
+        project_template_id:str,
+        project_title:str
+    ):
     try:
-        clone_project(token, org_name, project_template_id, project_title)
+        clone_project(repo, github_token, organization, target_repo_name, project_template_id, project_title)
         print("Project board has been set up successfully!")
     except Exception as e:
         print(f"Error occurred while setting up project board: {str(e)}")

--- a/audit_repo_cloner/create_audit_repo.py
+++ b/audit_repo_cloner/create_audit_repo.py
@@ -272,7 +272,7 @@ def prompt_for_details(
             )
         if not github_token:
             github_token = input(
-                f"\n{prompt_counter}) Enter you Github token: "
+                f"\n{prompt_counter}) Enter your Github token: "
             )
             prompt_counter += 1
         if not organization:

--- a/audit_repo_cloner/create_audit_repo.py
+++ b/audit_repo_cloner/create_audit_repo.py
@@ -132,11 +132,7 @@ def create_audit_repo(
             commit_hash,
         )
         repo = set_up_ci(repo, subtree_path)
-        # create project board optionally
-        if project_template_id and project_title:
-            set_up_project_board(repo, github_token, organization, target_repo_name, project_template_id, project_title)
-        else: 
-            print("Please set up project board manually.")
+        set_up_project_board(repo, github_token, organization, target_repo_name, project_template_id, project_title)
 
 
     print("Done!")
@@ -375,6 +371,7 @@ def create_and_clone_repo(
         repo = github_org.create_repo(target_repo_name, private=True)
     except GithubException as e:
         log.error(f"Error creating remote repository: {e}")
+        exit()
 
     try:
         print(f"Cloning {source_repo_name}...")
@@ -594,9 +591,11 @@ def set_up_project_board(
         github_token: str,
         organization: str,
         target_repo_name: str,
-        project_template_id:str,
-        project_title:str
+        project_template_id: str,
+        project_title: str = "DEFAULT PROJECT"
     ):
+    if not project_title:
+        project_title = "DEFAULT PROJECT"
     try:
         clone_project(repo, github_token, organization, target_repo_name, project_template_id, project_title)
         print("Project board has been set up successfully!")

--- a/audit_repo_cloner/create_audit_repo.py
+++ b/audit_repo_cloner/create_audit_repo.py
@@ -16,6 +16,7 @@ from constants import (
     ISSUE_TEMPLATE,
     DEFAULT_LABELS,
     SEVERITY_DATA,
+    PROJECT_TEMPLATE_ID,
 )
 
 log.basicConfig(level=log.INFO)
@@ -42,7 +43,6 @@ GITHUB_WORKFLOW_ACTION_NAME = "generate-report"
 @click.option("--auditors", help="Names of the auditors (separated by spaces).", default=os.getenv("ASSIGNED_AUDITORS"))
 @click.option("--github-token", help="Your GitHub developer token to make API calls.", default=os.getenv("GITHUB_ACCESS_TOKEN"))
 @click.option("--organization", help="Your GitHub organization name in which to clone the repo.", default=os.getenv("GITHUB_ORGANIZATION"))
-@click.option("--project-template-id", help="ID of the GitHub project board template.", default=os.getenv("PROJECT_TEMPLATE_ID"))
 @click.option("--project-title", help="Title of the new project board on GitHub.", default=os.getenv("PROJECT_TITLE"))
 def create_audit_repo(
     source_url: str = None,
@@ -51,7 +51,6 @@ def create_audit_repo(
     auditors: str = None,
     github_token: str = None,
     organization: str = None,
-    project_template_id: str = None,
     project_title: str = None
 ):
     """This function clones a target repository and prepares it for a Cyfrin audit using the provided arguments.
@@ -62,7 +61,6 @@ def create_audit_repo(
         auditors (str): A space-separated list of auditor names who will be assigned to the audit.
         github_token (str): The GitHub developer token to make API calls.
         organization (str): The GitHub organization to create the audit repository in.
-        project_template_id (str): The ID of the GitHub project board that can be extractable from the URL. e.g. https://github.com/orgs/Cyfrin/projects/5 -> 5 is the ID
         project_title (str): The title of the GitHub project board.
 
     Returns:
@@ -76,7 +74,6 @@ def create_audit_repo(
         auditors,
         github_token,
         organization,
-        project_template_id,
         project_title
     ) = prompt_for_details(
         source_url,
@@ -85,7 +82,6 @@ def create_audit_repo(
         auditors,
         github_token,
         organization,
-        project_template_id,
         project_title
     )
     if not source_url or not commit_hash or not auditors or not organization:
@@ -103,6 +99,7 @@ def create_audit_repo(
     source_repo_name = url_parts[-1]
     auditors_list: List[str] = [a.strip() for a in auditors.split(" ")]
     subtree_path = f"{SUBTREE_PATH_PREFIX}/{SUBTREE_NAME}"
+    project_template_id = PROJECT_TEMPLATE_ID
 
     # if target_repo_name is not provided, attempt to use the source repo name
     if not target_repo_name:
@@ -253,7 +250,6 @@ def prompt_for_details(
     auditors: str,
     github_token: str,
     organization: str,
-    project_template_id: str,
     project_title: str
 ):
     while True:
@@ -288,21 +284,16 @@ def prompt_for_details(
                 f"\n{prompt_counter}) Enter the name of the organization to create the audit repository in: "
             )
             prompt_counter += 1
-        if not project_template_id:
-            project_template_id = input(
-                f"\n{prompt_counter}) Enter the ID of the GitHub project board template (e.g. https://github.com/orgs/Cyfrin/projects/5/views/1 -> 5): "
-            )
-            prompt_counter += 1
         if not project_title:
             project_title = input(
                 f"\n{prompt_counter}) Enter the title of the GitHub project board: "
             )
             prompt_counter += 1
 
-        if source_url and commit_hash and auditors and github_token and organization and project_template_id and project_title:
+        if source_url and commit_hash and auditors and github_token and organization and project_title:
             break
         print("Please fill in all the details.")
-    return source_url, target_repo_name, commit_hash, auditors, github_token, organization, project_template_id, project_title
+    return source_url, target_repo_name, commit_hash, auditors, github_token, organization, project_title
 
 
 def try_clone_repo(

--- a/audit_repo_cloner/create_audit_repo.py
+++ b/audit_repo_cloner/create_audit_repo.py
@@ -96,7 +96,7 @@ def create_audit_repo(
     )
     if not source_url or not commit_hash or not auditors or not organization:
         raise click.UsageError(
-            "Source URL, commit hash, organization, and auditors must be provided either through config, or as options."
+            "Source URL, commit hash, organization, and auditors must be provided either through environment variables, or as options."
         )
     if not github_token:
         raise click.UsageError(

--- a/audit_repo_cloner/create_audit_repo.py
+++ b/audit_repo_cloner/create_audit_repo.py
@@ -60,7 +60,6 @@ def create_audit_repo(
     project_title: str = None
 ):
     """This function clones a target repository and prepares it for a Cyfrin audit using the provided arguments.
-    If config file is not provided, the user will be prompted for any parameter values not provided.
 
     Args:
         source_url (str): The URL of the source repository to be cloned and prepared for the Cyfrin audit.

--- a/audit_repo_cloner/github_project_utils.py
+++ b/audit_repo_cloner/github_project_utils.py
@@ -1,0 +1,82 @@
+import json
+import os
+import requests
+
+def get_organization_node_id(token: str, org_name: str)->str:
+    """
+    Get the GitHub organization's node id to use for later call to GraphQL
+        token (str): GitHub personal access token
+        org_name (str): GitHub organization name (username)
+
+        Return the node ID of the organization, empty string on failure
+    """
+    url = f"https://api.github.com/users/{org_name}"
+
+    payload = {}
+    headers = {
+    'Authorization': f'token {token}',
+    'Accept': 'application/vnd.github+json'
+    }
+
+    response = requests.request("GET", url, headers=headers, data=payload)
+    res = response.json()
+    return res.get('node_id', '')
+
+def get_project_node_id(token: str, org_name:str, project_template_id: str)->str:
+    """
+    Get the GitHub organization's node id to use for later call to GraphQL
+        token (str): GitHub personal access token
+        org_name (str): GitHub organization name (username)
+        project_template_id (str): ID of the project template, can be extracted from the link (e.g. https://github.com/orgs/KupiaSec/projects/7/views/2 => 7 is the ID)
+
+        Return the node ID of the project, empty string on failure
+    """
+     # get the project ID
+    url = "https://api.github.com/graphql"
+    payload = "{\"query\":\"query{organization(login: \\\""+org_name+"\\\") {projectV2(number: "+project_template_id+"){id}}}\",\"variables\":{}}"
+    headers = {
+        'Authorization': f'token {token}',
+    }
+    response = requests.request("POST", url, headers=headers, data=payload)
+    res = response.json()
+    return res.get('data', {}).get('organization', {}).get('projectV2', {}).get('id', '')
+
+
+def clone_project(token: str, org_name: str, project_template_id:str, project_title:str = '')->str:
+    """
+    Clone a GitHub project from the template
+        token (str): GitHub personal access token
+        org_node_id (str): GitHub Organization node ID (can be retrieved by calling get_organization_node_id)
+        project_template_id (str): ID of the project template, can be extracted from the link (e.g. https://github.com/orgs/KupiaSec/projects/7/views/2 => 7 is the ID)
+        project_title (Optional[str]): Name of the new project, if empty 'CLONED PROJECT' will be used.
+
+        Return the cloned project's ID, empty string on failure
+    """
+    if not org_name or not project_template_id:
+        return
+
+    if not project_title:
+        project_title = 'CLONED PROJECT'
+
+    # get the organization node id
+    org_node_id = get_organization_node_id(token, org_name)
+    if not org_node_id:
+        print('Failed to get the organization node ID.')
+        return
+
+    # get the project node id
+    project_node_id = get_project_node_id(token, org_name, project_template_id)
+
+    # clone the project
+    url = "https://api.github.com/graphql"
+    payload = '{"query":"mutation {copyProjectV2(input: {ownerId: \\\"' + org_node_id + '\\\" projectId: \\\"' + project_node_id + '\\\" title: \\\"' + project_title + '\\\"}) {projectV2 {id}}}\","variables":{}}'
+    headers = {
+        'Authorization': f'token {token}',
+    }
+
+    response = requests.request("POST", url, headers=headers, data=payload)
+    res = response.json()
+    return res.get('data', {}).get('organization', {}).get('projectV2', {}).get('id', '')
+
+
+

--- a/audit_repo_cloner/github_project_utils.py
+++ b/audit_repo_cloner/github_project_utils.py
@@ -159,7 +159,7 @@ def clone_project(repo: Repository, github_token: str, organization: str, target
         github_token (str): GitHub personal access token
         organization (str): GitHub organization name
         target_repo_name (str): Name of the repository with which the project will be associated
-        project_template_id (str): ID of the project template, can be extracted from the link (e.g. https://github.com/orgs/Cyfrin/projects/7/views/2 => 7 is the ID)
+        project_template_id (str): ID of the project template, can be extracted from the link (e.g. https://github.com/orgs/Cyfrin/projects/5/views/1 => 5 is the ID)
         project_title (str): Name of the new project.
 
         Return the cloned project's ID, empty string on failure

--- a/audit_repo_cloner/github_project_utils.py
+++ b/audit_repo_cloner/github_project_utils.py
@@ -47,7 +47,7 @@ def clone_project(token: str, org_name: str, project_template_id:str, project_ti
     Clone a GitHub project from the template
         token (str): GitHub personal access token
         org_node_id (str): GitHub Organization node ID (can be retrieved by calling get_organization_node_id)
-        project_template_id (str): ID of the project template, can be extracted from the link (e.g. https://github.com/orgs/KupiaSec/projects/7/views/2 => 7 is the ID)
+        project_template_id (str): ID of the project template, can be extracted from the link (e.g. https://github.com/orgs/Cyfrin/projects/7/views/2 => 7 is the ID)
         project_title (Optional[str]): Name of the new project, if empty 'CLONED PROJECT' will be used.
 
         Return the cloned project's ID, empty string on failure

--- a/audit_repo_cloner/github_project_utils.py
+++ b/audit_repo_cloner/github_project_utils.py
@@ -27,7 +27,7 @@ def get_project_node_id(token: str, org_name:str, project_template_id: str)->str
     Get the GitHub organization's node id to use for later call to GraphQL
         token (str): GitHub personal access token
         org_name (str): GitHub organization name (username)
-        project_template_id (str): ID of the project template, can be extracted from the link (e.g. https://github.com/orgs/KupiaSec/projects/7/views/2 => 7 is the ID)
+        project_template_id (str): ID of the project template, can be extracted from the link (e.g. https://github.com/orgs/Cyfrin/projects/7/views/2 => 7 is the ID)
 
         Return the node ID of the project, empty string on failure
     """

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ click==8.1.3
 cryptography==40.0.2
 Deprecated==1.2.13
 exceptiongroup==1.1.1
+gql==3.5.0
 idna==3.4
 iniconfig==2.0.0
 numpy==1.24.3
@@ -20,6 +21,7 @@ pytest==7.3.1
 python-dotenv==1.0.0
 PyYAML==6.0
 requests==2.29.0
+requests-toolbelt==1.0.0
 rsa==4.9
 tomli==2.0.1
 urllib3==1.26.15


### PR DESCRIPTION
Changes:
- Added GitHub project board utils.
- Added two new params for the project template ID and the project board title. The template ID can be extracted from the URL of the GitHub project.
- Removed "." in the import statements. It is solely because it gave me errors while working on the feature. Please check carefully.
- Removed the part reading params from config file thinking it's an unnecessary complication given that we already assume .env to be used.
- Revised all params to read default values from .env. The intention is to avoid inputting the source URL, commit hash, and so on repeatedly when the script fails. (maybe not anymore?)

TODO:
- [ ] Revise the README.txt
- [ ] Resolve relative import issue

Closes #14.